### PR TITLE
support user supplied migration table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ create `.eastrc` file at current directory
     "tables": ["card", "group", "user"],
     "database": {
         "name": "mydatabase",
+        "migrationTable": "mymigrationtable",
         "connection": {
             "host": "localhost",
             "port": 28015
@@ -45,7 +46,7 @@ create `.eastrc` file at current directory
 
 where 
 * `tables` is an array of the tables you wish to connect to in your database.
-* `database` is a json object with the following properties: `name` - database name, `connection` - a json object with `host` and `port` providing the host name and port number for your database respectively.
+* `database` is a json object with the following properties: `name` - database name, `migrationTable` - migration table name (optional - defaults to 'migration'), `connection` - a json object with `host` and `port` providing the host name and port number for your database respectively.
 
 now we can create some migrations
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -10,6 +10,10 @@ const Adapter = function (params) {
     if (!this.params.database) {
         throw new Error('Database Connection params should be set');
     }
+
+    if (typeof this.params.database.migrationTable !== 'string') {
+        this.params.database.migrationTable = 'migration';
+    }
 };
 
 Adapter.prototype.getTemplatePath = function () {
@@ -21,7 +25,7 @@ Adapter.prototype.connect = function (callback) {
 
     const self = this;
     const settings = Hoek.clone(self.params.database.connection);
-    const tableName = self.params.database.migrationTable || 'migration';
+    const tableName = this.params.database.migrationTable
     this.db = new Pensuer.Db(self.params.database.name, settings);
     this.db.table(self.params.tables);
     this.db.connect( (err) => {
@@ -52,7 +56,7 @@ Adapter.prototype.disconnect = function (callback) {
 Adapter.prototype.getExecutedMigrationNames = function (callback) {
 
     const self = this;
-    const tableName = self.params.database.migrationTable || 'migration';
+    const tableName = self.params.database.migrationTable;
 
     this.db[tableName].query({}, (err, migrations) => {
 
@@ -74,7 +78,7 @@ Adapter.prototype.getExecutedMigrationNames = function (callback) {
 Adapter.prototype.markExecuted = function (name, callback) {
 
     const self = this;
-    const tableName = self.params.database.migrationTable || 'migration';
+    const tableName = self.params.database.migrationTable;
 
     this.db[tableName].insert({ name: name, created: Date.now() }, (err, id) => {
 
@@ -89,7 +93,7 @@ Adapter.prototype.markExecuted = function (name, callback) {
 Adapter.prototype.unmarkExecuted = function (name, callback) {
 
     const self = this;
-    const tableName = self.params.database.migrationTable || 'migration';
+    const tableName = self.params.database.migrationTable;
 
     this.db[tableName].remove({ name: name }, (err) => {
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -25,7 +25,7 @@ Adapter.prototype.connect = function (callback) {
 
     const self = this;
     const settings = Hoek.clone(self.params.database.connection);
-    const tableName = this.params.database.migrationTable
+    const tableName = self.params.database.migrationTable;
     this.db = new Pensuer.Db(self.params.database.name, settings);
     this.db.table(self.params.tables);
     this.db.connect( (err) => {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -21,6 +21,7 @@ Adapter.prototype.connect = function (callback) {
 
     const self = this;
     const settings = Hoek.clone(self.params.database.connection);
+    const tableName = self.params.database.migrationTable || 'migration';
     this.db = new Pensuer.Db(self.params.database.name, settings);
     this.db.table(self.params.tables);
     this.db.connect( (err) => {
@@ -29,7 +30,7 @@ Adapter.prototype.connect = function (callback) {
             return callback(err);
         }
 
-        this.db.establish({ migration: { purge: false } }, (err) => {
+        this.db.establish({ [tableName]: { purge: false } }, (err) => {
 
             if (err) {
                 return callback(err);
@@ -50,7 +51,10 @@ Adapter.prototype.disconnect = function (callback) {
 
 Adapter.prototype.getExecutedMigrationNames = function (callback) {
 
-    this.db.migration.query({}, (err, migrations) => {
+    const self = this;
+    const tableName = self.params.database.migrationTable || 'migration';
+
+    this.db[tableName].query({}, (err, migrations) => {
 
         if (err) {
             return callback(err);
@@ -69,7 +73,10 @@ Adapter.prototype.getExecutedMigrationNames = function (callback) {
 
 Adapter.prototype.markExecuted = function (name, callback) {
 
-    this.db.migration.insert({ name: name, created: Date.now() }, (err, id) => {
+    const self = this;
+    const tableName = self.params.database.migrationTable || 'migration';
+
+    this.db[tableName].insert({ name: name, created: Date.now() }, (err, id) => {
 
         if (err) {
             return callback(err);
@@ -81,7 +88,10 @@ Adapter.prototype.markExecuted = function (name, callback) {
 
 Adapter.prototype.unmarkExecuted = function (name, callback) {
 
-    this.db.migration.remove({ name: name }, (err) => {
+    const self = this;
+    const tableName = self.params.database.migrationTable || 'migration';
+
+    this.db[tableName].remove({ name: name }, (err) => {
 
         if (err) {
             return callback(err);

--- a/lib/migrationTemplate.js
+++ b/lib/migrationTemplate.js
@@ -1,10 +1,13 @@
+'use strict';
 
-exports.migrate = function(client, done) {
-    var db = client.db;
+exports.migrate = (client, done) => {
+
+    const db = client.db;
     done();
 };
 
-exports.rollback = function(client, done) {
-    var db = client.db;
+exports.rollback = (client, done) => {
+
+    const db = client.db;
     done();
 };


### PR DESCRIPTION
This PR allows the user to set the migration table name in the config file. Will still default to `migration` if omitted.

Reading from the params in each function here, can introduce some shared state (or even refactor to be an es6 class) if you prefer.